### PR TITLE
Fix Ground DoT Ability Damage Tracking

### DIFF
--- a/cardcalc_damage.py
+++ b/cardcalc_damage.py
@@ -75,6 +75,7 @@ def calc_snapshot_damage(damage_events):
     damage_report = pd.DataFrame(summed_tick_damage, columns=[
                                  'timestamp', 'type', 'sourceID', 'targetID', 'abilityGameID', 'amount', 'hitType', 'directHit'])
     damage_report.sort_values(by='timestamp', inplace=True, ignore_index=True)
+
     return damage_report
 
 

--- a/cardcalc_damage.py
+++ b/cardcalc_damage.py
@@ -20,7 +20,6 @@ def calc_snapshot_damage(damage_events):
 
     for event in damage_events['tickDamage']:
         action = (event['sourceID'], event['targetID'], event['abilityGameID'])
-        if action[2] == 1000749: print(f"Checking {action[2]} from {action[0]} on {action[1]} as {event['type']}")
         
         # these events are either:
         # - apply{buff/debuff}
@@ -42,13 +41,10 @@ def calc_snapshot_damage(damage_events):
                     'timestamp': event['timestamp'],
                     'damage': 0,
                 }
-                if action[2] == 1000749: 
-                    print("Adding to active debuffs.")
-                    print(active_debuffs)
+
             # if it is an active debuff then add a new damage event associated
             # with the sum and restart summing the damage from this event
             else:
-                if action[2] == 1000749: print(f"Finalizing with amount: {active_debuffs[action]['damage']}")
                 summed_tick_damage.append({
                     'type': 'damagesnapshot',
                     'sourceID': action[0],
@@ -64,7 +60,6 @@ def calc_snapshot_damage(damage_events):
 
         elif event['type'] == 'damage':
             if action in active_debuffs:
-                if action[2] == 1000749: print(f"Adding {event['amount']} to total.")
                 active_debuffs[action]['damage'] += event['amount']
 
             # In the case of ground targeted AoEs!

--- a/cardcalc_fflogsapi.py
+++ b/cardcalc_fflogsapi.py
@@ -320,14 +320,16 @@ query reportData($code: String!, $startTime: Float!, $endTime: Float!) {
                 endTime: $endTime,
                 dataType: Buffs,
                 limit: 10000,
-                filterExpression: "ability.id in (1000749, 1000501, 1001205, 1000312, 1001869)"
+                filterExpression: "ability.id in (1000749, 1000501, 1002706, 1001205, 1000312, 1001869)"
             ) {
                 data
             }
         }
     }
 }
-"""
+""" 
+# Tick Events -> filterExpression id not in ?, ?, ?, ?
+# Ground Events -> filterExpression id in Salted Earth, Doton, Slipstream, ?, ?, ?
 
     data = call_fflogs_api(query, variables, token)
 

--- a/main.py
+++ b/main.py
@@ -120,8 +120,9 @@ def track_targets(report):
             startTime = int(startTime[:-3]) * 60 + int(startTime[-2:])
             
             is_opener = False
-            if startTime > 30: is_opener = True
+            if startTime < 31: is_opener = True
 
+            print(f"Adding Window Opening At: {startTime} | OPENER={is_opener}")
             for row in window['cardDamageTable']:
                 job = row['job']
                 damage = row['adjustedDamage']
@@ -152,9 +153,6 @@ def track_targets(report):
             sql_data.append(
                 (job, card, encounter_id, difficulty, avg, max, total, opener)
             )
-
-        for s in sql_data:
-            print(s)
 
         sql = "INSERT INTO targets(job, cardId, encounterId, difficulty, average, max, total, opener) VALUES %s;"
         psycopg2.extras.execute_values(cur, sql, sql_data)
@@ -395,6 +393,7 @@ def encounter_report(encounter):
     non_opener_melee = []
 
     for r in ranged_list:
+        print(r)
         if r[1]: opener_ranged.append(r)
         else: non_opener_ranged.append(r)
 

--- a/main.py
+++ b/main.py
@@ -134,7 +134,7 @@ def track_targets(report):
                 else:
                     db_avg, db_max, total = job_result
                     total+=1
-                    new_avg = db_avg + (total - db_avg) / (total + 1)
+                    new_avg = db_avg + (damage - db_avg) / (total + 1)
 
                     if (db_max < damage): db_max = damage
 

--- a/main.py
+++ b/main.py
@@ -133,9 +133,9 @@ def track_targets(report):
                 if (job_result == None): cleaned_data[(job, card, is_opener)] = [damage, damage, 1]
                 else:
                     db_avg, db_max, total = job_result
-                    # My understanding is that Python Longs don't overflow so theoretically this is fine forever even if naive(?)
-                    new_avg = ((db_avg * total) + damage) / (total + 1)
-                    total+=1 
+                    total+=1
+                    new_avg = db_avg + (total - db_avg) / (total + 1)
+
                     if (db_max < damage): db_max = damage
 
                     cleaned_data[(job, card, is_opener)] = [new_avg, db_max, total]

--- a/main.py
+++ b/main.py
@@ -93,6 +93,7 @@ WHERE computed < {};""".format(computed_cutoff)
     client.close()
 
 def track_targets(report):
+    print(report)
     client = psycopg2.connect(database=PG_DB, host=PG_SERVER, user=PG_USER, password=PG_PW, port=PG_PORT)
     cur = client.cursor()
 
@@ -122,7 +123,7 @@ def track_targets(report):
                     job_result = cleaned_data[(job, card)]
                 else:
                     job_result = None
-                sql = "SELECT average, max, total FROM targets WHERE job=%s AND cardId=%s AND encounterId=%s AND difficulty=%s;"
+                # sql = "SELECT average, max, total FROM targets WHERE job=%s AND cardId=%s AND encounterId=%s AND difficulty=%s;"
                 # cur.execute(sql, (job, card, encounter_id, difficulty))
                 # job_result = cur.fetchone()
 
@@ -330,6 +331,7 @@ def calc(report_id, fight_id):
 
 @app.route('/encounter/<string:encounter>/')
 def encounter_report(encounter):
+    print(encounter)
     client = psycopg2.connect(database=PG_DB, host=PG_SERVER, user=PG_USER, password=PG_PW, port=PG_PORT)
     cur = client.cursor()
 
@@ -342,7 +344,7 @@ def encounter_report(encounter):
         cleaned_encounters.append((e[0]))
     
     # This is not my favorite way to do this but it does work and is very concise.
-    lower_list = [e.lower() for e in cleaned_encounters]
+    lower_list = [e.lower().replace(" ", "") for e in cleaned_encounters]
 
     try:
         index = lower_list.index(encounter.lower())
@@ -363,7 +365,10 @@ def encounter_report(encounter):
     for item in encounter_data:
         # We will need difficulty later for distinguishing between normal and savage. It does not matter for ex.
         job, card, difficulty, average, max, total = item
+
+        # Smile
         job = job[0].upper() + job[1:]
+
         if card == 37023:
             melee_list.append((job, average, max, total))
         elif card == 37026:

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ PG_DB = "cardcalc"
 PG_PORT = "5432"
 
 app = Flask(__name__)
-LAST_CALC_DATE = pytz.UTC.localize(datetime.utcfromtimestamp(1663886556))
+LAST_CALC_DATE = pytz.UTC.localize(datetime.now())
 token = get_bearer_token()
 
 client = psycopg2.connect(database=PG_DB, host=PG_SERVER, user=PG_USER, password=PG_PW, port=PG_PORT)
@@ -390,4 +390,3 @@ def encounter_report(encounter):
     melee_list = [opener_melee, non_opener_melee]
 
     return render_template('encounter.html', ranged_list=ranged_list, melee_list=melee_list, encounter=encounter)
-    # return render_template('encounter.html', data=data)

--- a/rebuild_totals.py
+++ b/rebuild_totals.py
@@ -1,0 +1,65 @@
+import os, json
+from collections import OrderedDict
+import psycopg2
+
+from main import track_targets
+
+PG_USER = os.environ['PG_USER']
+PG_PW = os.environ['PG_PASSWORD']
+
+PG_SERVER = "50.116.36.193"
+# PG_SERVER = "127.0.0.1"
+PG_DB = "cardcalc"
+PG_PORT = "5432"
+
+client = psycopg2.connect(database=PG_DB, host=PG_SERVER, user=PG_USER, password=PG_PW, port=PG_PORT)
+cur = client.cursor()
+
+sql = """SELECT * FROM reports"""
+cur.execute(sql)
+reports = cur.fetchall()
+
+# Create backup in case interrupted or data is otherwise mangled.
+sql = """DROP TABLE IF EXISTS targetsbu;"""
+cur.execute(sql)
+
+sql = """CREATE TABLE targetsbu AS TABLE targets;"""
+cur.execute(sql)
+
+sql = """TRUNCATE TABLE targets;"""
+cur.execute(sql)
+
+client.commit()
+client.close()
+
+# Unforutnately there's some issues that I need to fix on the reports tracking side. This will prevent duplicates in the interim.
+calculated_reports = []
+
+for r in reports:
+    report_id, fight_id, results, actors, enc_name, enc_time, enc_kill, computed, difficulty = r
+
+    #if enc_name.lower() == "doomtrain": continue
+    if (report_id, fight_id) in calculated_reports: continue
+    report = {
+            'report_id': report_id,
+            'fight_id': fight_id,
+            'results': json.loads(results),
+            'actors': json.loads(actors),
+            'enc_name': enc_name,
+            'enc_time': enc_time,
+            'enc_kill': enc_kill,
+            'computed': computed,
+            'difficulty': difficulty,
+        }
+    print(f"Adding {enc_name} : {report_id}/{fight_id} to targets.")
+    
+    # Cleanup results data so that it appears as expected to the track_targets function.
+    report['results'] = list(OrderedDict(
+        sorted(report['results'].items())).values())
+    
+    track_targets(report)
+    calculated_reports.append((report_id, fight_id))
+
+
+# NOTE: MODIFY PROD TABLE
+# ALTER TABLE reports ADD COLUMN difficulty INT DEFAULT 100;

--- a/templates/encounter.html
+++ b/templates/encounter.html
@@ -1,0 +1,114 @@
+{% extends 'base.html' %}
+
+<span><ActionFetch name="The Balance" :id="37023" /></span> - Melee
+
+{% block content %}
+    <h1>Job Performance Tracking</h1>
+    <div class="card mb-4 p-2">
+        <img id="doomtrain" src="https://assets.rpglogs.com/img/ff/bosses/1083-icon.jpg">
+        <h5 class="card-title"> {{ encounter }} </h5>
+    </div>
+    
+    <p>Please note: This is a naive implementation which will be progressively improved. Information on the methodology can be found at the bottom of the page.</p>
+    <div class="tabset">
+        <input 
+            type="radio" 
+            id="tab-cardplay" 
+            name="tab-cards" 
+            checked
+            aria-hidden="true"
+        >
+        <input 
+            type="radio" 
+            id="tab-details" 
+            name="tab-cards" 
+            aria-hidden="true"
+        >
+        <ul aria-hidden="true">
+            <li><label for="tab-cardplay"><span><ActionFetch name="The Balance" :id="37023" /></span> - Melee</label></li>
+            <li><label for="tab-details"><span><ActionFetch name="The Spear" :id="37026" /></span> - Ranged</label></li>
+        </ul>
+    <div>
+        <section>
+            <h2>The Balance - Melee</h2>
+            <div class="content">
+                    <div class="col">
+                        <div class="table-responsive-md">
+                            <table class="table table-striped">
+                                <thead>
+                                    <div>
+                                        <tr>
+                                            <th scope="col">
+                                                Job
+                                            </th>
+                                            <th scope="col">
+                                                <span data-toggle="tooltip" data-placement="bottom" title="The median of all logged pull data.">Average</span>
+                                            </th>
+                                            <th scope="col">
+                                                Max
+                                            <th scope="col">
+                                                <span data-toggle="tooltip" data-placement="bottom" title="Total number of windows used to obtain the average.">Total</span>
+                                            </th>
+                                        </tr>
+                                    </div>
+                                </thead>
+                                <tbody>
+                                        {% for m in melee_list %}
+                                        <tr>
+                                            <td>{{ m[0] }}</td>
+                                            <td>{{ m[1] }}</td>
+                                            <td>{{ m[2] }}</td>
+                                            <td>{{ m[3] }}</td>
+                                        {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                <hr>
+        </section>
+
+        <section>
+            <h2>The Spear - Ranged</h2>
+            <div class="content">
+                <div class="col">
+                        <div class="table-responsive-md">
+                            <table class="table table-striped">
+                                <thead>
+                                    <div>
+                                        <tr>
+                                            <th scope="col">
+                                                Job
+                                            </th>
+                                            <th scope="col">
+                                                <span data-toggle="tooltip" data-placement="bottom" title="The median of all logged pull data.">Average</span>
+                                            </th>
+                                            <th scope="col">
+                                                Max
+                                            <th scope="col">
+                                                <span data-toggle="tooltip" data-placement="bottom" title="Total number of windows used to obtain the average.">Total</span>
+                                            </th>
+                                        </tr>
+                                    </div>
+                                </thead>
+                                <tbody>
+                                        {% for m in ranged_list %}
+                                        <tr>
+                                            <td>{{ m[0] }}</td>
+                                            <td>{{ m[1] }}</td>
+                                            <td>{{ m[2] }}</td>
+                                            <td>{{ m[3] }}</td>
+                                        {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                <hr>
+            </div>
+        </section>
+        </div>
+    </div>
+
+    <h2>Methodology: </h2>
+
+{% endblock %}

--- a/templates/encounter.html
+++ b/templates/encounter.html
@@ -186,7 +186,7 @@
             that the card calculator finds. 
         </p>
         <p>Every time the average is updated, it's re-calculated using the following: </p>
-        <code>new_average = ((old_average * total) + damage_from_damage_window) / (total + 1)</code>
+        <code>new_average = old_average + (damage_from_damage_window - old_average) / (number_of_data_points + 1)</code>
         <h3 class="pt-3">Changes I'd Like To Make:</h3>
         <ul>
             <li>Ignore outlier data, specifically if the damage is exceptionally low compared to the existing average. This would also help with any windows being ended early beacuse of killtime.</li>

--- a/templates/encounter.html
+++ b/templates/encounter.html
@@ -178,11 +178,12 @@
     <div class="mb-2">
         <h2>Methodology:</h2>
         <p><b>Windows in a fight are only counted towards the total tracked average if the boss is killed.</b></p>
+        <p> If a card is played within thirty seconds of the fight starting, the window is considered a part of the opener.</p>
         <p>
             Every time a card is played, the card calculator checks the damage done during the duration of the card by all players. 
-            This is compiled into an average (mean) based on the total number of windows checked. The card calculator also finds the
-            ideal play time in the range that the card was available. I haven't included that 
-            data yet because there's a couple of issues, primarily that sometimes the 'ideal' window is not possible.
+            This is compiled into an average (mean) based on the total number of windows checked. Maximum and averages are currently 
+            both being calculated at the moment the card is played. In the future, I will include data from the 'ideal' card uses
+            that the card calculator finds. 
         </p>
         <p>Every time the average is updated, it's re-calculated using the following: </p>
         <code>new_average = ((old_average * total) + damage_from_damage_window) / (total + 1)</code>

--- a/templates/encounter.html
+++ b/templates/encounter.html
@@ -1,11 +1,13 @@
 {% extends 'base.html' %}
 
-<span><ActionFetch name="The Balance" :id="37023" /></span> - Melee
-
 {% block content %}
-    <h1>Job Performance Tracking</h1>
     <div class="card mb-4 p-2">
-        <img id="doomtrain" src="https://assets.rpglogs.com/img/ff/bosses/1083-icon.jpg">
+        {% if encounter=="Doomtrain"%}
+        <img src="https://assets.rpglogs.com/img/ff/bosses/1083-icon.jpg">
+        {% elif encounter=="Futures Rewritten" %}
+        <img src="https://assets.rpglogs.com/img/ff/zones/zone-65.png">
+        {% endif %}
+
         <h5 class="card-title"> {{ encounter }} </h5>
     </div>
     
@@ -109,6 +111,23 @@
         </div>
     </div>
 
-    <h2>Methodology: </h2>
+    <div class="mb-2">
+        <h2>Methodology:</h2>
+        <p>
+            Every time a card is played, the card calculator checks the damage done during the duration of the card by all players. 
+            This is compiled into an average (mean) based on the total number of windows checked. The card calculator also finds the
+            ideal play time in the range that the card was available. I haven't included that 
+            data yet because there's a couple of issues, primarily that sometimes the 'ideal' window is not possible.
+        </p>
+        <p>Every time the average is updated, it's re-calculated using the following: </p>
+        <code>new_average = ((old_average * total) + damage_from_damage_window) / (total + 1)</code>
+        <h3 class="pt-3">Changes I'd Like To Make:</h3>
+        <ul>
+            <li>Ignore outlier data, specifically if the damage is exceptionally low compared to the existing average.</li>
+            <li>Incorporate the 'true' optimal target which the calculator calculates.</li>
+            <li>There's probably a better way to count / maintain the average. Since (my understanding it) Python longs don't 
+                overflow, this should be fine indefinitely, however I doubt it's the 'best' way.</li>
+        </ul>
+    </div>
 
 {% endblock %}

--- a/templates/encounter.html
+++ b/templates/encounter.html
@@ -36,6 +36,7 @@
             <div class="content">
                     <div class="col">
                         <div class="table-responsive-md">
+                            <h3>Opener:</h3>
                             <table class="table table-striped">
                                 <thead>
                                     <div>
@@ -55,13 +56,44 @@
                                     </div>
                                 </thead>
                                 <tbody>
-                                        {% for m in melee_list %}
+                                        {% for m in melee_list[0] %}
                                         <tr>
                                             <td>{{ m[0] }}</td>
-                                            <td>{{ m[1] }}</td>
-                                            <td>{{ m[2] }}</td>
                                             <td>{{ m[3] }}</td>
+                                            <td>{{ m[4] }}</td>
+                                            <td>{{ m[5] }}</td>
                                         {% endfor %}
+                                        
+                                </tbody>
+                            </table>
+                            <h3>2M Burst:</h3>
+                            <table class="table table-striped">
+                                <thead>
+                                    <div>
+                                        <tr>
+                                            <th scope="col">
+                                                Job
+                                            </th>
+                                            <th scope="col">
+                                                <span data-toggle="tooltip" data-placement="bottom" title="The mean of all logged pull data.">Average</span>
+                                            </th>
+                                            <th scope="col">
+                                                Max
+                                            <th scope="col">
+                                                <span data-toggle="tooltip" data-placement="bottom" title="Total number of windows used to obtain the average.">Total</span>
+                                            </th>
+                                        </tr>
+                                    </div>
+                                </thead>
+                                <tbody>
+                                        {% for m in melee_list[1] %}
+                                        <tr>
+                                            <td>{{ m[0] }}</td>
+                                            <td>{{ m[3] }}</td>
+                                            <td>{{ m[4] }}</td>
+                                            <td>{{ m[5] }}</td>
+                                        {% endfor %}
+                                        
                                 </tbody>
                             </table>
                         </div>
@@ -75,6 +107,7 @@
             <div class="content">
                 <div class="col">
                         <div class="table-responsive-md">
+                            <h3>Opener:</h3>
                             <table class="table table-striped">
                                 <thead>
                                     <div>
@@ -83,7 +116,7 @@
                                                 Job
                                             </th>
                                             <th scope="col">
-                                                <span data-toggle="tooltip" data-placement="bottom" title="The median of all logged pull data.">Average</span>
+                                                <span data-toggle="tooltip" data-placement="bottom" title="The mean of all logged pull data.">Average</span>
                                             </th>
                                             <th scope="col">
                                                 Max
@@ -94,13 +127,44 @@
                                     </div>
                                 </thead>
                                 <tbody>
-                                        {% for m in ranged_list %}
+                                        {% for m in ranged_list[0] %}
                                         <tr>
                                             <td>{{ m[0] }}</td>
-                                            <td>{{ m[1] }}</td>
-                                            <td>{{ m[2] }}</td>
                                             <td>{{ m[3] }}</td>
+                                            <td>{{ m[4] }}</td>
+                                            <td>{{ m[5] }}</td>
                                         {% endfor %}
+                                        
+                                </tbody>
+                            </table>
+                            <h3>2M Burst:</h3>
+                            <table class="table table-striped">
+                                <thead>
+                                    <div>
+                                        <tr>
+                                            <th scope="col">
+                                                Job
+                                            </th>
+                                            <th scope="col">
+                                                <span data-toggle="tooltip" data-placement="bottom" title="The mean of all logged pull data.">Average</span>
+                                            </th>
+                                            <th scope="col">
+                                                Max
+                                            <th scope="col">
+                                                <span data-toggle="tooltip" data-placement="bottom" title="Total number of windows used to obtain the average.">Total</span>
+                                            </th>
+                                        </tr>
+                                    </div>
+                                </thead>
+                                <tbody>
+                                        {% for m in ranged_list[1] %}
+                                        <tr>
+                                            <td>{{ m[0] }}</td>
+                                            <td>{{ m[3] }}</td>
+                                            <td>{{ m[4] }}</td>
+                                            <td>{{ m[5] }}</td>
+                                        {% endfor %}
+                                        
                                 </tbody>
                             </table>
                         </div>

--- a/templates/encounter.html
+++ b/templates/encounter.html
@@ -191,9 +191,9 @@
         <ul>
             <li>Ignore outlier data, specifically if the damage is exceptionally low compared to the existing average. This would also help with any windows being ended early beacuse of killtime.</li>
             <li>Incorporate the 'true' optimal target which the calculator calculates.</li>
-            <li>There's probably a better way to count / maintain the average. Since (my understanding it) Python longs don't 
+            <li>There's probably a better way to count / maintain the average. Since (my understanding is) Python longs don't 
                 overflow, this should be fine indefinitely, however I doubt it's the 'best' way.</li>
-            <li>It would be idea to differentiate between windows that have pots active, or which are openers.</li>
+            <li>It would be ideal to differentiate between windows that have pots active, or which are openers.</li>
         </ul>
     </div>
 

--- a/templates/encounter.html
+++ b/templates/encounter.html
@@ -44,7 +44,7 @@
                                                 Job
                                             </th>
                                             <th scope="col">
-                                                <span data-toggle="tooltip" data-placement="bottom" title="The median of all logged pull data.">Average</span>
+                                                <span data-toggle="tooltip" data-placement="bottom" title="The mean of all logged pull data.">Average</span>
                                             </th>
                                             <th scope="col">
                                                 Max
@@ -113,6 +113,7 @@
 
     <div class="mb-2">
         <h2>Methodology:</h2>
+        <p><b>Windows in a fight are only counted towards the total tracked average if the boss is killed.</b></p>
         <p>
             Every time a card is played, the card calculator checks the damage done during the duration of the card by all players. 
             This is compiled into an average (mean) based on the total number of windows checked. The card calculator also finds the
@@ -123,10 +124,11 @@
         <code>new_average = ((old_average * total) + damage_from_damage_window) / (total + 1)</code>
         <h3 class="pt-3">Changes I'd Like To Make:</h3>
         <ul>
-            <li>Ignore outlier data, specifically if the damage is exceptionally low compared to the existing average.</li>
+            <li>Ignore outlier data, specifically if the damage is exceptionally low compared to the existing average. This would also help with any windows being ended early beacuse of killtime.</li>
             <li>Incorporate the 'true' optimal target which the calculator calculates.</li>
             <li>There's probably a better way to count / maintain the average. Since (my understanding it) Python longs don't 
                 overflow, this should be fine indefinitely, however I doubt it's the 'best' way.</li>
+            <li>It would be idea to differentiate between windows that have pots active, or which are openers.</li>
         </ul>
     </div>
 


### PR DESCRIPTION
This includes a fix for ground target DoTs (Doton, Slipstream, and Salted Earth) to fix their tracking. 

Previously the code checked to see if the current action was in the action list. Each action was built out of its source, its target, and its action id. This worked for standard DoTs, but in the case of ground-targeted DoTs such as Salted Earth, the initial target id is the player which cast the ability, not the entity the ability was damaging. 

The main code for this fix is the following:
```python
if action in active_debuffs:
    active_debuffs[action]['damage'] += event['amount']
# New code below:
elif (action[0], action[0], action[2]) in active_debuffs:
    active_debuffs[(action[0], action[0], action[2])]['damage'] += event['amount']
```

Where the elif block checks to see if there's a GT AoE instance active before discarding the damage because it doesn't know what event it's attached too.

This pull also includes the framework for the average tracking which I plan to fully implement in time for the upcoming Savage tier.